### PR TITLE
Added moment.js to required scripts

### DIFF
--- a/MMM-NowPlayingOnSpotify.js
+++ b/MMM-NowPlayingOnSpotify.js
@@ -44,7 +44,7 @@ Module.register('MMM-NowPlayingOnSpotify', {
   getScripts: function () {
     return [
       this.file('core/NPOS_DomBuilder.js'),
-	  'moment.js'
+      'moment.js'
     ];
   },
 

--- a/MMM-NowPlayingOnSpotify.js
+++ b/MMM-NowPlayingOnSpotify.js
@@ -43,7 +43,8 @@ Module.register('MMM-NowPlayingOnSpotify', {
 
   getScripts: function () {
     return [
-      this.file('core/NPOS_DomBuilder.js')
+      this.file('core/NPOS_DomBuilder.js'),
+	  'moment.js'
     ];
   },
 


### PR DESCRIPTION
If no other modules require moment.js, this module stays in "Loading..." with the following console.log:

```
Uncaught ReferenceError: moment is not defined
    at NPOS_DomBuilder.getTimeInfo (NPOS_DomBuilder.js:112)
    at NPOS_DomBuilder.getPlayingContent (NPOS_DomBuilder.js:95)
    at NPOS_DomBuilder.getDom (NPOS_DomBuilder.js:13)
    at Class.getDom (MMM-NowPlayingOnSpotify.js:30)
    at updateDom (main.js:99)
    at Object.updateDom (main.js:468)
    at Class.updateDom (module.js:358)
    at Class.socketNotificationReceived (MMM-NowPlayingOnSpotify.js:55)
    at module.js:246
    at r.<anonymous> (socketclient.js:25)
```

This just adds moment.js to the required scripts.