### PR TITLE
Add format to current position

### DIFF
--- a/core/NPOS_DomBuilder.js
+++ b/core/NPOS_DomBuilder.js
@@ -112,7 +112,7 @@ class NPOS_DomBuilder {
     let currentPos = moment.duration(context.progress);
     let length = moment.duration(context.titleLength);
 
-    return currentPos.format() + ' / ' + length.format();
+    return currentPos.format(mm:ss) + ' / ' + length.format(mm:ss);
   }
 
   getInfoDiv(symbol, text) {


### PR DESCRIPTION
It makes more sense to have the current position in a song be "00:32 / 03:44" than "32 / 3:44".