### PR TITLE
added hide image when nothing is playing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ There is not very much to configure but here are the options:
 
 | Option | Description |
 |--------|-------------|
+| `hideImageWhenNothingIsPlaying` | <p>A boolean value decribing whether the spotify image should be displayed or not if nothing is playing.</p><p>**Type:** `boolean` **OPTIONAL**<br>**Example:** `true`<br>**Default Value:** `false`</p> |
 | `showCoverArt` | <p>A boolean value decribing whether an album cover photo should be displayed or not.</p><p>**Type:** `boolean` **OPTIONAL**<br>**Example:** `false`<br>**Default Value:** `true`</p> |
 | `updatesEvery` | <p>An integer determining the interval for display updates.</p><p>**Type:** `integer` **OPTIONAL**<br>**Example:** `5`<br>**Default Value:** `1`</p><p>**Note:** With the default setting the display is updated every second. So when you skip to the next song it is virtually immediately visible. Also the progress bar runs smoothly. If you increase the value you may relieve the strain on your Raspberry’s processor but your display will not be as up-to-date. </p> |
 | `clientID` | <p>A string describing the `clientID` of your Spotify app.</p><p>**Type:** `string` **REQUIRED**<br>**Example:** `"acecg8a4..."`<br>**Default Value:** none</p><p>**Note:** The easiest way to get that value is by copying the code snippet from step 3 in the [authorisation app](#step-2-–-create-and-authorise-a-spotify-app).</p> |
@@ -90,6 +91,7 @@ Here is an example for an entry in `config.js`
     position: "top_right",
 
     config: {
+		hideImageWhenNothingIsPlaying: false,
         showCoverArt: false,
         clientID: "<YOUR_CLIENT_ID>",
         clientSecret: "<YOUR_CLIENT_SECRET>",

--- a/core/NPOS_DomBuilder.js
+++ b/core/NPOS_DomBuilder.js
@@ -42,8 +42,9 @@ class NPOS_DomBuilder {
   getNothingIsPlayingContent() {
     let content = document.createElement('div');
     content.className = 'NPOS_nothingIsPlayingContent';
-    content.appendChild(this.getLogoImage());
-
+    if (!this.config.hideImageWhenNothingIsPlaying) {
+        content.appendChild(this.getLogoImage());
+    }
     return content;
   }
 


### PR DESCRIPTION
imho, it is better to hide gui elements when they don't show any information so that you have more free space in the mirror.