### PR TITLE
fix: replace request-promise-native with native fetch in SpotifyConnector

### DIFF
--- a/core/SpotifyConnector.js
+++ b/core/SpotifyConnector.js
@@ -1,14 +1,11 @@
 'use strict';
 
-const request = require('request-promise-native');
 const moment = require('moment');
 
 const tokenRefreshEndpoint = 'https://accounts.spotify.com/api/token';
 const apiEndpoint = 'https://api.spotify.com/v1/me/player';
 
-
 module.exports = class SpotifyConnector {
-
   constructor(credentials) {
     this.credentials = credentials;
     this.tokenExpiresAt = moment();
@@ -17,48 +14,54 @@ module.exports = class SpotifyConnector {
   retrieveCurrentlyPlaying() {
     if (moment().isBefore(this.tokenExpiresAt)) {
       return this.getSpotifyData();
-
     } else {
       return this.refreshAccessToken()
         .then((response) => {
-          console.log('Refreshed access token because it has expired. Expired at: %s now is: %s',
-            this.tokenExpiresAt.format('HH:mm:ss'), moment().format('HH:mm:ss'));
-
+          console.log(
+            'Refreshed access token. Expired at: %s, now: %s',
+            this.tokenExpiresAt.format('HH:mm:ss'),
+            moment().format('HH:mm:ss')
+          );
           this.credentials.accessToken = response.access_token;
           this.tokenExpiresAt = moment().add(response.expires_in, 'seconds');
-
           return this.getSpotifyData();
         })
         .catch((err) => {
-          console.error('Error while refreshing:');
-          console.error(err);
+          console.error('Error while refreshing access token:', err);
+          throw err;
         });
     }
   }
 
-  getSpotifyData() {
-    let options = {
-      url: apiEndpoint,
-      headers: {'Authorization': 'Bearer ' + this.credentials.accessToken},
-      json: true
-    };
+  async getSpotifyData() {
+    const res = await fetch(apiEndpoint, {
+      headers: { 'Authorization': 'Bearer ' + this.credentials.accessToken }
+    });
 
-    return request.get(options);
+    if (res.status === 204) return null; // No song playing
+    if (!res.ok) throw new Error(`Spotify API error: ${res.status}`);
+
+    return res.json();
   }
 
-  refreshAccessToken() {
-    let client_id = this.credentials.clientID;
-    let client_secret = this.credentials.clientSecret;
-    let options = {
-      url: tokenRefreshEndpoint,
-      headers: { 'Authorization': 'Basic ' + (new Buffer(client_id + ':' + client_secret).toString('base64')) },
-      form: {
-        grant_type: 'refresh_token',
-        refresh_token: this.credentials.refreshToken
-      },
-      json: true
-    };
+  async refreshAccessToken() {
+    const { clientID, clientSecret, refreshToken } = this.credentials;
+    const basicAuth = Buffer.from(`${clientID}:${clientSecret}`).toString('base64');
 
-    return request.post(options);
+    const res = await fetch(tokenRefreshEndpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${basicAuth}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken
+      })
+    });
+
+    if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`);
+
+    return res.json();
   }
 };

--- a/node_helper.js
+++ b/node_helper.js
@@ -25,22 +25,25 @@ module.exports = NodeHelper.create({
   },
 
 
-  retrieveCurrentSong: function () {
-    this.connector.retrieveCurrentlyPlaying()
-      .then((response) => {
-        if (response) {
-          this.sendRetrievedNotification(response);
-        } else {
-          this.sendRetrievedNotification({ noSong: true });
-        }
-      })
-      .catch((error) => {
-        console.error('Can’t retrieve current song. Reason: ');
-        console.error(error);
-      });
-  },
+        retrieveCurrentSong: function () {
+          if (!this.connector) {
+            console.warn('MMM-NowPlayingOnSpotify: connector not ready, skipping update.');
+            return;
+          }
+          this.connector.retrieveCurrentlyPlaying()
+            .then((response) => {
+              if (response) {
+                this.sendRetrievedNotification(response);
+              } else {
+                this.sendRetrievedNotification({ noSong: true });
+              }
+            })
+            .catch((error) => {
+              console.error('Can\'t retrieve current song. Reason: ', error);
+            });
+        },
 
-
+        
   sendRetrievedNotification: function (songInfo) {
     let payload = songInfo;
 

--- a/package.json
+++ b/package.json
@@ -30,13 +30,11 @@
     "node": ">=7"
   },
   "dependencies": {
-    "cookie-parser": "1.4.3",
-    "express": "~4.16.0",
+    "body-parser": "^1.18.2",
+    "cookie-parser": "^1.4.7",
+    "express": "^4.22.2",
     "moment-duration-format": "^2.2.2",
-    "npm": "^5.7.1",
-    "querystring": "~0.2.0",
-    "request": "^2.83.0",
-    "request-promise-native": "^1.0.5",
-    "body-parser": "^1.18.2"
+    "npm": "^11.14.1",
+    "querystring": "~0.2.0"
   }
 }


### PR DESCRIPTION
Removes the deprecated request and request-promise-native packages which carried 4 vulnerabilities (2 critical, 2 moderate) with no upstream fix. Rewrites SpotifyConnector using Node 22 built-in fetch and URLSearchParams. Also replaces deprecated new Buffer() with Buffer.from() and adds a null guard in node_helper to prevent crashes when UPDATE_CURRENT_SONG fires before CONNECT_TO_SPOTIFY.